### PR TITLE
Maintain counts behavior

### DIFF
--- a/data/hazards.txt
+++ b/data/hazards.txt
@@ -18,8 +18,8 @@ hazard "Ember Waste Base Heat"
 hazard "Ember Waste Base Storm"
 	"duration" 300 1500
 	"strength" 1 3
-	"environmental effect" "ion hazard" 2
 	"system-wide"
+	"environmental effect" "ion hazard" 20
 	weapon
 		"ion damage" 0.5
 		"shield damage" 5

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -2108,6 +2108,7 @@ void Engine::DoWeather(Weather &weather)
 	{
 		const Hazard *hazard = weather.GetHazard();
 		const DamageProfile damage(weather.GetInfo());
+
 		// Get all ship bodies that are touching a ring defined by the hazard's min
 		// and max ranges at the hazard's origin. Any ship touching this ring takes
 		// hazard damage.

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -1414,7 +1414,7 @@ void Engine::CalculateStep()
 
 	// Step the weather.
 	for(Weather &weather : activeWeather)
-		weather.Step(newVisuals, flagship ? &flagship->Position() : nullptr);
+		weather.Step(newVisuals, flagship ? flagship->Position() : center);
 	Prune(activeWeather);
 
 	// Move the visuals.

--- a/source/Hazard.h
+++ b/source/Hazard.h
@@ -38,8 +38,9 @@ public:
 	// Generates a random double between the minimum and maximum strength of this hazard.
 	double RandomStrength() const;
 	// Whether this hazard affects every ship in the system irrespective of its distance from the
-	// hazard origin. It will be shown around it, in a circle encompassing the whole visible screen.
-	// The minRange will still be taken into consideration.
+	// hazard origin. System-wide hazards use the center of the screen as the origin point for
+	// environmental effects. The min range is then the range around the center in which effects
+	// won't be drawn, while the max range becomes the bounds of the screen.
 	bool SystemWide() const;
 	// The minimum and maximum distances from the origin in which this hazard has an effect.
 	double MinRange() const;

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -14,7 +14,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 #include "Angle.h"
 #include "Hazard.h"
-#include "pi.h"
 #include "Screen.h"
 #include "Visual.h"
 #include "Random.h"
@@ -77,23 +76,33 @@ void Weather::Step(vector<Visual> &visuals, const Point &center)
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.
 	double minRange = hazard->MinRange();
-	// If it is systemwide, only draw around the flagship.
-	double maxRange = hazard->SystemWide() ? 2. * (Screen::Width() > Screen::Height() ?
-		Screen::Width() : Screen::Height()) : hazard->MaxRange();
+	double maxRange = hazard->MaxRange();
+	double effectMultiplier = currentStrength;
 
-	// Calculate how many squares of 1000x1000 fit into the circle we're going to draw in.
-	double sizeMultiplier = 2. * PI * maxRange * maxRange / (1000. * 1000.);
+	// If a hazard is system-wide, the max range becomes the edge of the screen,
+	// and the number of effects drawn is scaled accordingly.
+	if(hazard->SystemWide())
+	{
+		// Find the larger of the two screen dimensions, and use that as our new
+		// max range.
+		double newMax = 2. * max(Screen::Width(), Screen::Height());
+		// Maintain the same density of effects by dividing the new area
+		// by the old. (The pis cancel out and therefore need not be taken
+		// into account.)
+		effectMultiplier *= (newMax * newMax) / (maxRange * maxRange);
+		maxRange = newMax;
+	}
+
 	// Estimate the number of visuals to be generated this frame.
 	// MAYBE: create only a subset of possible effects per frame.
 	int totalAmount = 0;
 	for(auto &&effect : hazard->EnvironmentalEffects())
 		totalAmount += effect.second;
-	totalAmount *= currentStrength * sizeMultiplier;
+	totalAmount *= effectMultiplier;
 	visuals.reserve(visuals.size() + totalAmount);
 
 	for(auto &&effect : hazard->EnvironmentalEffects())
-		// The amount of the effect is specified for a square of 1000x1000.
-		for(int i = 0; i < effect.second * currentStrength * sizeMultiplier; ++i)
+		for(int i = 0; i < effect.second * effectMultiplier; ++i)
 		{
 			Point angle = Angle::Random().Unit();
 			double magnitude = (maxRange - minRange) * sqrt(Random::Real());

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -16,7 +16,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include "Hazard.h"
 #include "pi.h"
 #include "Screen.h"
-#include "Ship.h"
 #include "Visual.h"
 #include "Random.h"
 

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -72,7 +72,7 @@ const Point &Weather::Origin() const
 
 
 // Create any environmental effects and decrease the lifetime of this weather.
-void Weather::Step(vector<Visual> &visuals, const Point *effectCenter)
+void Weather::Step(vector<Visual> &visuals, const Point &center)
 {
 	// Environmental effects are created by choosing a random angle and distance from
 	// their origin, then creating the effect there.
@@ -97,7 +97,7 @@ void Weather::Step(vector<Visual> &visuals, const Point *effectCenter)
 		{
 			Point angle = Angle::Random().Unit();
 			double magnitude = (maxRange - minRange) * sqrt(Random::Real());
-			Point pos = ((hazard->SystemWide() && effectCenter) ? *effectCenter : origin)
+			Point pos = (hazard->SystemWide() ? center : origin)
 				+ (minRange + magnitude) * angle;
 			visuals.emplace_back(*effect.first, std::move(pos), Point(), Angle::Random());
 		}

--- a/source/Weather.cpp
+++ b/source/Weather.cpp
@@ -93,23 +93,28 @@ void Weather::Step(vector<Visual> &visuals, const Point &center)
 		maxRange = newMax;
 	}
 
-	// Estimate the number of visuals to be generated this frame.
-	// MAYBE: create only a subset of possible effects per frame.
-	int totalAmount = 0;
-	for(auto &&effect : hazard->EnvironmentalEffects())
-		totalAmount += effect.second;
-	totalAmount *= effectMultiplier;
-	visuals.reserve(visuals.size() + totalAmount);
+	// Don't draw effects if a system-wide hazard moved the max range to 
+	// be less than the min range.
+	if(minRange <= maxRange)
+	{
+		// Estimate the number of visuals to be generated this frame.
+		// MAYBE: create only a subset of possible effects per frame.
+		int totalAmount = 0;
+		for(auto &&effect : hazard->EnvironmentalEffects())
+			totalAmount += effect.second;
+		totalAmount *= effectMultiplier;
+		visuals.reserve(visuals.size() + totalAmount);
 
-	for(auto &&effect : hazard->EnvironmentalEffects())
-		for(int i = 0; i < effect.second * effectMultiplier; ++i)
-		{
-			Point angle = Angle::Random().Unit();
-			double magnitude = (maxRange - minRange) * sqrt(Random::Real());
-			Point pos = (hazard->SystemWide() ? center : origin)
-				+ (minRange + magnitude) * angle;
-			visuals.emplace_back(*effect.first, std::move(pos), Point(), Angle::Random());
-		}
+		for(auto &&effect : hazard->EnvironmentalEffects())
+			for(int i = 0; i < effect.second * effectMultiplier; ++i)
+			{
+				Point angle = Angle::Random().Unit();
+				double magnitude = (maxRange - minRange) * sqrt(Random::Real());
+				Point pos = (hazard->SystemWide() ? center : origin)
+					+ (minRange + magnitude) * angle;
+				visuals.emplace_back(*effect.first, std::move(pos), Point(), Angle::Random());
+			}
+	}
 
 	if(--lifetimeRemaining <= 0)
 		shouldBeRemoved = true;

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -18,7 +18,6 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <vector>
 
 class Hazard;
-class Ship;
 class Visual;
 class Weapon;
 
@@ -40,7 +39,7 @@ public:
 
 public:
 	Weather() = default;
-	explicit Weather(const Hazard *hazard, int totalLifetime, int lifetimeRemaining, double strength, Point flagshipPosition);
+	explicit Weather(const Hazard *hazard, int totalLifetime, int lifetimeRemaining, double strength, Point origin);
 
 	// The hazard that is associated with this weather event.
 	const Hazard *GetHazard() const;

--- a/source/Weather.h
+++ b/source/Weather.h
@@ -50,7 +50,7 @@ public:
 	// The origin of the hazard.
 	const Point &Origin() const;
 	// Create any environmental effects and decrease the lifetime of this weather.
-	void Step(std::vector<Visual> &newVisuals, const Point *effectCenter = nullptr);
+	void Step(std::vector<Visual> &newVisuals, const Point &center);
 	// Calculate this weather's strength for the current frame, to be used to find
 	// out what the current period and damage multipliers are.
 	void CalculateStrength();


### PR DESCRIPTION
* CHORE: Cleaned up some code that was no longer necessary.
* BUG FIX: Changed Weather::Step to accept a reference Point instead of a pointer Point, and use the screen center if the flagship isn't available. With the previous code, the player losing their flagship would mean that effects would be moved to the hazard origin.
* BUG FIX: If the screen bounds are smaller than the min range of the hazard, don't bother drawing any effects.
* FEAT: Maintain the current behavior of the number defined for effects being a count of how many effects per frame are created within the range instead of a density of how many effects are created per frame in a 1000x1000 area.
* FEAT: System-wide hazards adjust the count given to them based off of the screen bounds as compared to the range if the hazard wasn't system-wide in order to maintain the same density regardless of screen size.