### PR TITLE
Path to Glory 7: Add space before substitution

### DIFF
--- a/data/hai/unfettered 1 alphas.txt
+++ b/data/hai/unfettered 1 alphas.txt
@@ -873,7 +873,7 @@ mission "<uhai> 7: Cavalry Arrives"
 	on enter
 		conversation
 			"As you enter the system it becomes clear: they have called for backup! Multiple pirate ships are arriving in the system. But you also see other ships arriving by jump drives. They do not appear to be pirates, maybe the 'contact' has provided help as well?"
-			`They hail you, "Listen carefully. You may have noticed a Korath drone in the area, and they don't like Alpha dogs around much. If Korath come to help, do not open fire on them, understood?" "I would recommend you make sure these pirate ships are on your side<, unfettered title>!" The other ship adds, before ending the hail, making it clear they will not take no for an answer.`
+			`They hail you, "Listen carefully. You may have noticed a Korath drone in the area, and they don't like Alpha dogs around much. If Korath come to help, do not open fire on them, understood?" "I would recommend you make sure these pirate ships are on your side <, unfettered title>!" The other ship adds, before ending the hail, making it clear they will not take no for an answer.`
 	npc save
 		government "Shadow"
 		personality entering heroic uninterested staying mute


### PR DESCRIPTION
Substitution is missing a space and so runs words together: "are on your sideoutsider."

![image](https://user-images.githubusercontent.com/70952724/221021372-b1f01261-61d5-4494-abb8-c0e1cf20e73a.png)
